### PR TITLE
mrc-3772: Iterate styling

### DIFF
--- a/assets/css/extended/list_styles.css
+++ b/assets/css/extended/list_styles.css
@@ -1,0 +1,43 @@
+.list {
+    background: var(--theme);
+}
+
+.first-entry {
+    min-height: unset;
+}
+
+.post-entry {
+    position: relative;
+    margin-bottom: var(--gap);
+    padding: unset;
+    background: unset;
+    border-radius: var(--radius);
+    transition: transform 0.1s;
+    border: unset;
+}
+
+.post-entry:hover {
+    text-decoration: underline;
+}
+
+.entry-content {
+    margin: 8px 0;
+    color: var(--primary);
+    font-size: unset;
+    line-height: 1.6;
+    overflow: hidden;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+}
+
+.entry-content .date {
+    font-size: 14px;
+    display: inline-block;
+    min-width: 80px;
+}
+
+.entry-content .title {
+    margin-left: 10px;
+    margin-right: 10px;
+}

--- a/assets/css/extended/post_styles.css
+++ b/assets/css/extended/post_styles.css
@@ -1,0 +1,7 @@
+.paginav {
+    font-size: medium;
+    margin: 10px 0;
+    display: flex;
+    line-height: 30px;
+    border-radius: var(--radius);
+}

--- a/assets/css/extended/tag_styles.css
+++ b/assets/css/extended/tag_styles.css
@@ -1,0 +1,42 @@
+.post-entry .post-tags {
+    display: inline-block;
+}
+
+.post-entry-tag ul {
+    list-style-type: disc;
+}
+
+.post-tags a {
+    display: block;
+    padding-inline-start: 10px;
+    padding-inline-end: 10px;
+    color: var(--secondary);
+    font-size: 14px;
+    font-weight: 600;
+    line-height: 34px;
+    background: var(--code-bg);
+}
+
+.post-tags a:active {
+    transition: transform 0.1s;
+    transform: scale(0.98);
+}
+
+.post-tags a.Feature {
+    background-color: var(--theme);
+    color: #14CC80;
+}
+
+.post-tags a.Update {
+    background-color: var(--theme);
+    color: #FFBA11;
+}
+
+.post-tags a.Model {
+    background-color: var(--theme);
+    color: #E31837;
+}
+
+.post-tags:hover {
+    text-decoration: unset;
+}

--- a/assets/css/extended/theme-vars.css
+++ b/assets/css/extended/theme-vars.css
@@ -1,0 +1,34 @@
+:root {
+    --gap: 24px;
+    --content-gap: 20px;
+    --nav-width: 1024px;
+    --main-width: 720px;
+    --header-height: 60px;
+    --footer-height: 60px;
+    --radius: 8px;
+    --theme: rgb(255, 255, 255);
+    --entry: rgb(255, 255, 255);
+    --primary: rgb(30, 30, 30);
+    --secondary: rgb(108, 108, 108);
+    --tertiary: rgb(214, 214, 214);
+    --content: rgb(31, 31, 31);
+    --hljs-bg: rgb(28, 29, 33);
+    --code-bg: rgb(245, 245, 245);
+    --border: rgb(238, 238, 238);
+}
+
+.dark {
+    --theme: rgb(29, 30, 32);
+    --entry: rgb(46, 46, 51);
+    --primary: rgb(218, 218, 219);
+    --secondary: rgb(155, 156, 157);
+    --tertiary: rgb(65, 66, 68);
+    --content: rgb(196, 196, 197);
+    --hljs-bg: rgb(46, 46, 51);
+    --code-bg: rgb(55, 56, 62);
+    --border: rgb(51, 51, 51);
+}
+
+.dark.list {
+    background: var(--theme);
+}

--- a/config.yml
+++ b/config.yml
@@ -6,11 +6,15 @@ enableEmoji: true
 
 params:
   # https://github.com/adityatelange/hugo-PaperMod/wiki/Installation#sample-configyml
-  DateFormat: "1 January 2006"
+  DateFormat: "1 Jan 2006"
   disableThemeToggle: true
   defaultTheme: light
   disableSpecial1stPost: true
   hideMeta: false
+  ShowPostNavLinks: true
+  homeInfoParams:
+    Title: Naomi news site
+    Content: What's new and updated in the Naomi UI and model
 
 menu:
   main:

--- a/config.yml
+++ b/config.yml
@@ -13,7 +13,7 @@ params:
   hideMeta: false
   ShowPostNavLinks: true
   homeInfoParams:
-    Title: Naomi news site
+    Title: Naomi News Site
     Content: What's new and updated in the Naomi UI and model
 
 menu:

--- a/config.yml
+++ b/config.yml
@@ -22,7 +22,3 @@ menu:
       name: Tags
       url: /tags/
       weight: 20
-    - identifier: epimodels
-      name: EpiModels
-      url: https://epimodels.dide.ic.ac.uk
-      weight: 30

--- a/content/posts/comparison-barchart.md
+++ b/content/posts/comparison-barchart.md
@@ -1,7 +1,7 @@
 ---
 title: "New output plot: Comparison barchart"
 date: 2022-08-31
-hint_version: 2.9.0
+version: ["hint v2.9.0"]
 pull_request: https://github.com/mrc-ide/hint/pull/728
 tags: ["Feature"]
 ---

--- a/content/posts/data-exploration.md
+++ b/content/posts/data-exploration.md
@@ -1,7 +1,7 @@
 ---
 title: "Data exploration: a standalone input data viewer"
 date: 2021-11-24
-hint_version: 1.76.0
+version: ["hint v1.76.0"]
 pull_request: https://github.com/mrc-ide/hint/pull/624
 tags: ["Feature"]
 ---

--- a/content/posts/default-options.md
+++ b/content/posts/default-options.md
@@ -1,7 +1,7 @@
 ---
 title: "All model fit and calibration options will now be set by default"
 date: 2022-09-26
-hintr_version: 1.0.41
+version: ["hintr v1.0.41"]
 pull_request: https://github.com/mrc-ide/hintr/pull/405
 tags: ["Update"]
 ---

--- a/content/posts/project-load.md
+++ b/content/posts/project-load.md
@@ -1,7 +1,7 @@
 ---
 title: "Model output zip can now be loaded to view outputs"
 date: 2022-07-18
-hint_version: 2.4.0
+version: ["hint v2.4.0"]
 pull_request: https://github.com/mrc-ide/hint/pull/716
 tags: ["Feature"]
 ---

--- a/content/posts/project-notes-zip.md
+++ b/content/posts/project-notes-zip.md
@@ -1,7 +1,7 @@
 ---
 title: "Project notes added to output zip"
 date: 2022-06-20
-hint_version: 2.2.0
+version: ["hint 2.2.0"]
 pull_request: https://github.com/mrc-ide/hint/pull/710
 tags: ["Feature"]
 ---

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,0 +1,90 @@
+{{- define "main" }}
+
+{{- if (and site.Params.profileMode.enabled .IsHome) }}
+{{- partial "index_profile.html" . }}
+{{- else }} {{/* if not profileMode */}}
+
+{{- if not .IsHome | and .Title }}
+<header class="page-header">
+  {{- partial "breadcrumbs.html" . }}
+  <h1>
+    {{ .Title }}
+    {{- if and (or (eq .Kind `term`) (eq .Kind `section`)) (.Param "ShowRssButtonInSectionTermList") }}
+    <a href="index.xml" title="RSS" aria-label="RSS">
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+        stroke-linecap="round" stroke-linejoin="round" height="23">
+        <path d="M4 11a9 9 0 0 1 9 9" />
+        <path d="M4 4a16 16 0 0 1 16 16" />
+        <circle cx="5" cy="19" r="1" />
+      </svg>
+    </a>
+    {{- end }}
+  </h1>
+  {{- if .Description }}
+  <div class="post-description">
+    {{ .Description | markdownify }}
+  </div>
+  {{- end }}
+</header>
+{{- end }}
+
+{{- if .Content }}
+<div class="post-content">
+  {{- if not (.Param "disableAnchoredHeadings") }}
+  {{- partial "anchored_headings.html" .Content -}}
+  {{- else }}{{ .Content }}{{ end }}
+</div>
+{{- end }}
+
+{{- $pages := union .RegularPages .Sections }}
+
+{{- if .IsHome }}
+{{- $pages = where site.RegularPages "Type" "in" site.Params.mainSections }}
+{{- $pages = where $pages "Params.hiddenInHomeList" "!=" "true"  }}
+{{- end }}
+
+{{- $paginator := .Paginate $pages }}
+
+{{- if and .IsHome site.Params.homeInfoParams (eq $paginator.PageNumber 1) }}
+{{- partial "home_info.html" . }}
+{{- end }}
+
+{{- $term := .Data.Term }}
+{{- range $index, $page := $paginator.Pages }}
+
+{{- $class := "post-entry" }}
+
+{{- $user_preferred := or site.Params.disableSpecial1stPost site.Params.homeInfoParams }}
+{{- if (and $.IsHome (eq $paginator.PageNumber 1) (eq $index 0) (not $user_preferred)) }}
+{{- $class = "first-entry" }}
+{{- else if $term }}
+{{- $class = "post-entry tag-entry" }}
+{{- end }}
+
+<div class="{{ $class }}">
+    {{- $isHidden := (site.Params.cover.hidden | default site.Params.cover.hiddenInList) }} {{- partial "cover.html" (dict "cxt" . "IsHome" true "isHidden" $isHidden) }}
+    <div class="entry-content">
+        {{- partial "post_title.html" . -}}
+    </div>
+
+    <a class="entry-link" aria-label="post link to {{ .Title | plainify }}" href="{{ .Permalink }}"></a>
+</div>
+{{- end }} {{- if gt $paginator.TotalPages 1 }}
+<footer class="page-footer">
+    <nav class="pagination">
+        {{- if $paginator.HasPrev }}
+        <a class="prev" href="{{ $paginator.Prev.URL | absURL }}">
+      «&nbsp;{{ i18n "prev_page" }}&nbsp;
+      {{- if (.Param "ShowPageNums") }}
+      {{- sub $paginator.PageNumber 1 }}/{{ $paginator.TotalPages }}
+      {{- end }}
+    </a> {{- end }} {{- if $paginator.HasNext }}
+        <a class="next" href="{{ $paginator.Next.URL | absURL }}">
+      {{- i18n "next_page" }}&nbsp;
+      {{- if (.Param "ShowPageNums") }}
+      {{- add 1 $paginator.PageNumber }}/{{ $paginator.TotalPages }}
+      {{- end }}&nbsp;»
+    </a> {{- end }}
+    </nav>
+</footer>
+{{- end }} {{- end }}{{/* end profileMode */}} {{- end }}{{- /* end main */ -}}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,0 +1,58 @@
+{{- define "main" }}
+
+<article class="post-single">
+  <header class="post-header">
+    {{ partial "breadcrumbs.html" . }}
+    <h1 class="post-title">
+      {{ .Title }}
+      {{- if .Draft }}<sup><span class="entry-isdraft">&nbsp;&nbsp;[draft]</span></sup>{{- end }}
+    </h1>
+    {{- if .Description }}
+    <div class="post-description">
+      {{ .Description }}
+    </div>
+    {{- end }}
+    {{- if not (.Param "hideMeta") }}
+    <div class="post-meta">
+      {{- partial "post_meta.html" . -}}
+      {{- partial "translation_list.html" . -}}
+      {{- partial "edit_post.html" . -}}
+      {{- partial "post_canonical.html" . -}}
+    </div>
+    {{- end }}
+  </header>
+  {{- $isHidden := .Params.cover.hidden | default site.Params.cover.hiddenInSingle | default site.Params.cover.hidden }}
+  {{- partial "cover.html" (dict "cxt" . "IsHome" false "isHidden" $isHidden) }}
+  {{- if (.Param "ShowToc") }}
+  {{- partial "toc.html" . }}
+  {{- end }}
+
+  {{- if .Content }}
+  <div class="post-content">
+    {{- if not (.Param "disableAnchoredHeadings") }}
+    {{- partial "anchored_headings.html" .Content -}}
+    {{- else }}{{ .Content }}{{ end }}
+  </div>
+  {{- end }}
+
+  <footer class="post-footer">
+    {{- $tags := .Language.Params.Taxonomies.tag | default "tags" }}
+    <ul class="post-tags">
+      {{- range ($.GetTerms $tags) }}
+      <li><a href="{{ .Permalink }}" class="{{ .LinkTitle }}">{{ .LinkTitle }}</a></li>
+      {{- end }}
+    </ul>
+    {{- if (.Param "ShowPostNavLinks") }}
+    {{- partial "post_nav_links.html" . }}
+    {{- end }}
+    {{- if (and site.Params.ShowShareButtons (ne .Params.disableShare true)) }}
+    {{- partial "share_icons.html" . -}}
+    {{- end }}
+  </footer>
+
+  {{- if (.Param "comments") }}
+  {{- partial "comments.html" . }}
+  {{- end }}
+</article>
+
+{{- end }}{{/* end main */}}

--- a/layouts/partials/post_meta.html
+++ b/layouts/partials/post_meta.html
@@ -1,0 +1,25 @@
+{{- $scratch := newScratch }}
+
+{{- if not .Date.IsZero -}}
+{{- $scratch.Add "meta" (slice (printf "<span title='%s'>%s</span>" (.Date) (.Date | time.Format (default "January 2, 2006" site.Params.DateFormat)))) }}
+{{- end }}
+
+{{ range .Params.version }}
+  {{- $scratch.Add "meta" (slice (printf "<span>%s</span>" (.))) }}
+{{ end }}
+
+{{- if (.Param "ShowReadingTime") -}}
+{{- $scratch.Add "meta" (slice (i18n "read_time" .ReadingTime | default (printf "%d min" .ReadingTime))) }}
+{{- end }}
+
+{{- if (.Param "ShowWordCount") -}}
+{{- $scratch.Add "meta" (slice (i18n "words" .WordCount | default (printf "%d words" .WordCount))) }}
+{{- end }}
+
+{{- with (partial "author.html" .) }}
+{{- $scratch.Add "meta" (slice .) }}
+{{- end }}
+
+{{- with ($scratch.Get "meta") }}
+{{- delimit . "&nbsp;·&nbsp;" -}}
+{{- end -}}

--- a/layouts/partials/post_title.html
+++ b/layouts/partials/post_title.html
@@ -1,0 +1,20 @@
+{{- $scratch := newScratch }}
+
+{{- if not .Date.IsZero -}}
+{{- $scratch.Add "post-title" (slice (printf "<span class='date' title='%s'>%s</span>" (.Date) (.Date | time.Format (default "January 2, 2006" site.Params.DateFormat)))) }}
+{{- end }}
+
+{{- $scratch.Add "post-title" (slice (printf "<span class='title'>%s</span>" (.Title) ))}}
+
+{{- with ($scratch.Get "post-title") }}
+{{- delimit . "" -}}
+{{- end -}}
+
+<span class="post-tags">
+{{- $tags := .Language.Params.Taxonomies.tag | default "tags" }}
+<ul>
+  {{- range ($.GetTerms $tags) }}
+  <li><a href="{{ .Permalink }}" class={{ .LinkTitle }}>{{ .LinkTitle }}</a></li>
+  {{- end }}
+</ul>
+</span>


### PR DESCRIPTION
This overrides some of the theme styling to look a bit more like buildkite changelogs it
* Show tags on the main page next to the post title
* Styles tags with colours (only for 3 types feature, update or model we can add more if we want in future but the "model" tag is quite specific to naomi news site)
* Remove link to epi models
* Make each post entry smaller and only show the title and date
* Add next/previous buttons to posts
* Show version info in post metadata

If we want we could make this into a fork of the theme and use it for other news sites, if so we should probably make the tags and their colours configurable
