### PR TITLE
Set base URL to use HTTPS

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -1,4 +1,4 @@
-baseURL: "http://reside-ic.github.io/naomi-news/"
+baseURL: "https://reside-ic.github.io/naomi-news/"
 languageCode: "en-gb"
 title: "Naomi News"
 theme: "PaperMod"


### PR DESCRIPTION
The proxy redirect is not working because the base URL is using http. Meaning if we proxy at https://reside-ic.github.io then the styles are not loaded as it doesn't match the base URL. But if we proxy http:// then that redirects to https site changing the URL in the browser