### PR TITLE
Add deploy script

### DIFF
--- a/scripts/deploy
+++ b/scripts/deploy
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -eux
+
+USER=vagrant
+HOST=naomi-dev.dide.ic.ac.uk
+DIR=/
+OUTPUT_DIR=news
+
+hugo -b https://naomi-dev.dide.ic.ac.uk/news -d ${OUTPUT_DIR}
+
+function cleanup {
+    rm -rf $OUTPUT_DIR
+}
+trap cleanup EXIT
+
+tar c ${OUTPUT_DIR} | ssh ${USER}@${HOST} docker cp - hint_proxy:${DIR}
+
+exit 0

--- a/scripts/deploy
+++ b/scripts/deploy
@@ -2,18 +2,38 @@
 
 set -eux
 
-USER=vagrant
-HOST=naomi-dev.dide.ic.ac.uk
-DIR=/
+DEST_DIR=/
 OUTPUT_DIR=news
 
-hugo -b https://naomi-dev.dide.ic.ac.uk/news -d ${OUTPUT_DIR}
+mkdir $OUTPUT_DIR
 
 function cleanup {
     rm -rf $OUTPUT_DIR
 }
 trap cleanup EXIT
 
-tar c ${OUTPUT_DIR} | ssh ${USER}@${HOST} docker cp - hint_proxy:${DIR}
+function release_site {
+    hugo -b $1 -d ${OUTPUT_DIR}
+    tar c ${OUTPUT_DIR} | ssh $2@$3 docker cp - hint_proxy:${DEST_DIR}
+}
+
+## Sites are a string of format
+## URL USER HOST
+## URL is the full URL of the news site
+## USER is the user to ssh as
+## HOST the the address to ssh to
+declare -A SITES=(
+    ["dev"]="https://naomi-dev.dide.ic.ac.uk/news vagrant naomi-dev.dide.ic.ac.uk"
+    ["staging"]="https://naomi-staging.dide.ic.ac.uk/news vagrant naomi-staging.dide.ic.ac.uk"
+    ["preview"]="https://naomi-preview.dide.ic.ac.uk/news vagrant naomi-preview.dide.ic.ac.uk"
+    ["production"]="https://naomi.unaids.org/news vagrant naomi.dide.ic.ac.uk"
+)
+
+for site in "${!SITES[@]}"; do
+    echo "Deploying to $site"
+    release_site ${SITES[$site]}
+done
+
+echo "Deployment completed"
 
 exit 0


### PR DESCRIPTION
This script builds the hugo site and copies the files into the proxy container on naomi dev, staging, preview and production.

This then works with https://github.com/mrc-ide/hint-proxy/pull/4 to serve the static files. 

I did it this way with a deploy script instead of having the proxy redirect to reside-ic.github.io because I was having issues with the hugo site because of paths to other files.

If we proxy_pass from `news` to `reside-ic.github.io/naomi-news` then the main HTML works but the style sheet is referenced from hugo at `/naomi-news/assets/...` which is then not found without another redirect rule from `naomi-news` to `news`. Then the links from the `naomi-news` site to the content posts are to the full URL e.g. https://reside-ic.github.io/naomi-news/posts/comparison-barchart/ which then changes the users URL in their browser without a rule in the proxy which does a regex match to change the returned HTML content. That would also only work with 1 base URL, so naomi-dev would end up redirecting to prod system. It was getting quite fiddly and I thought might be simpler to just add a script here to copy static files to each server into the nginx container and serve the files from there.

You can see this working at naomi-dev.dide.ic.ac.uk/news