### PR TITLE
Fix time format

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -6,7 +6,7 @@ enableEmoji: true
 
 params:
   # https://github.com/adityatelange/hugo-PaperMod/wiki/Installation#sample-configyml
-  DateFormat: "1 Jan 2006"
+  DateFormat: "2 Jan 2006"
   disableThemeToggle: true
   defaultTheme: light
   disableSpecial1stPost: true


### PR DESCRIPTION
The 1 "1 Jan 2006" indicates show the month whereas 2 shows the day..

see https://gohugohq.com/howto/hugo-dateformat/